### PR TITLE
Mogelijkheid om Amsterdam.pm elders te houden

### DIFF
--- a/bin/announce_amsterdam_pm.pl
+++ b/bin/announce_amsterdam_pm.pl
@@ -10,29 +10,53 @@ use Getopt::Long;
 my %opt = (
     production => 0,
     force => 0,
+    place => 'linghong',
 );
 GetOptions \%opt => qw/
     production|p
     force|f
+    place=s
 /;
-    
 
-if ( $opt{force} || is_amsterdam_announce() ) {
-    send_email()
+my %amsterdam_place = (
+    linghong => {
+        name   => 'Restaurant Ling Hong',
+        street => 'Ouddiemerlaan 15',
+        place  => 'Diemen',
+        url    => 'http://www.eet.nu/diemen/ling-hong',
+    },
+    techinc => {
+        name   => 'Technologia Incognita',
+        street => 'Louwesweg 1',
+        place  => 'Amsterdam',
+        url    => 'http://www.techinc.nl',
+    },
+);
+
+if (not exists $amsterdam{ $opt{place} }) {
+    die "Onbekende plaats voor bijeenkomst: $opt{place}\n";
 }
 
+if ( $opt{force} || is_amsterdam_announce() ) {
+    send_email( $amsterdam_place{$opt{place}} )
+}
+
+
 sub send_email {
+    my ($place) = @_;
     my @args = (
         next_amsterdam_meeting(),
-        'Restaurant Ling Hong',
-        'Ouddiemerlaan 15',
-        'Diemen',
-        'http://www.eet.nu/diemen/ling-hong',
+        $place{name},
+        $place{street},
+        $place{place},
+        $place{url},
+        $place{name},
         next_amsterdam_meeting(),
-        'Restaurant Ling Hong',
-        'Ouddiemerlaan 15',
-        'Diemen',
-        'http://www.eet.nu/diemen/ling-hong',
+        $place{name},
+        $place{street},
+        $place{place},
+        $place{url},
+        $place{name},
     );
     my $body = sprintf(<<'    EOM', @args);
 [English version follows the dutch text]
@@ -61,7 +85,7 @@ De eerstvolgende bijeenkomst vindt plaats op dinsdag %s van
 Zie %s voor details.
 
 Liefhebbers van een etentje vooraf kunnen reeds tussen 18:00 en 18:30
-naar het restaurant komen om een hapje te eten.
+naar %s komen om een hapje te eten.
 
 Bezoek onze Web site http://perl.nl/amsterdam voor meer details.
 
@@ -86,7 +110,7 @@ Our next meeting is Tuesday, %s, from 20:00 till 22:30 at the
 See %s for a description.
 
 If you want to join some of us for dinner, please gather between 18:00
-and 18:30 at the restaurant.
+and 18:30 at %s.
 
 See http://perl.nl/amsterdam for more details.
 -- 

--- a/lib/Amsterdam.pm
+++ b/lib/Amsterdam.pm
@@ -8,8 +8,9 @@ our $VERSION = '0.1';
 
 get '/' => sub {
     template 'amsterdam' => {
-        title => 'Amsterdam Perl Mongers',
-        meeting_date => next_amsterdam_meeting(),
+        title         => 'Amsterdam Perl Mongers',
+        meeting_date  => next_amsterdam_meeting(),
+        meeting_place => 'techinc.tt',
     };
 };
 

--- a/views/amsterdam.tt
+++ b/views/amsterdam.tt
@@ -23,10 +23,7 @@ Ter inzage, bespreekbaar en te koop met 20% korting!
 <div id="sidebar">
 <h2>volgende bijeenkomst</h2>
 <p>Dinsdag [% meeting_date %].
-In <a
-     href="https://maps.google.nl/maps?q=Ling+Hong+B.V.,+Ouddiemerlaan+15,+Diemen&hl=nl&sll=52.634651,4.736248&sspn=0.007084,0.017359&oq=Ling+Hong+Ouddiemerlaan+15,+Diemen&hq=ling+hong+bv&hnear=Ouddiemerlaan+15,+Diemen,+Noord-Holland&t=m&z=16"
-     target="_blank">Ling Hong</a>: Ouddiemerlaan 15 1111GS Diemen.<br />
-<a href="http://www.eet.nu/diemen/ling-hong">Waardering</a>: 8.9
+[% include $meeting_place %]
 Zie mailinglist.
 </p>
 <h2>recente onderwerpen</h2>

--- a/views/linghong.tt
+++ b/views/linghong.tt
@@ -1,0 +1,5 @@
+In <a
+     href="https://maps.google.nl/maps?q=Ling+Hong+B.V.,+Ouddiemerlaan+15,+Diemen&hl=nl&sll=52.634651,4.736248&sspn=0.007084,0.017359&oq=Ling+Hong+Ouddiemerlaan+15,+Diemen&hq=ling+hong+bv&hnear=Ouddiemerlaan+15,+Diemen,+Noord-Holland&t=m&z=16"
+     target="_blank">Ling Hong</a>: Ouddiemerlaan 15 1111GS Diemen.<br />
+<a href="http://www.eet.nu/diemen/ling-hong">Waardering</a>: 8.9
+

--- a/views/techinc.tt
+++ b/views/techinc.tt
@@ -1,0 +1,3 @@
+In <a
+      href="https://www.google.nl/maps/place/Technologia+Incognita,+Louwesweg+1,+1066+EA+Amsterdam/@52.3454862,4.8264313,17z/data=!4m2!3m1!1s0x47c5e18860bc2deb:0x4bde8a58895ecf8a"
+      target=_blank>Tech Inc.</a> Louwesweg 1 1066EA Amsterdam.


### PR DESCRIPTION
Voor iedere meetingplace is voor de website een template gekomen.
Tevens data voor de mailinglist (die met een --place optie anders kan).

We moeten even nadenken over hoe we deze bijeenkomstplaats via een filetje of database kunnen doorgeven aan de software. Voor nu kunnen we in ieder geval september netjes oplossen.